### PR TITLE
pool switch refactor mvp

### DIFF
--- a/main/http_server/http_server.c
+++ b/main/http_server/http_server.c
@@ -659,7 +659,7 @@ static esp_err_t GET_system_info(httpd_req_t * req)
     cJSON_AddStringToObject(root, "bestSessionDiff", SYSTEM_MODULE.best_session_diff_string);
     cJSON_AddNumberToObject(root, "poolDifficulty", POOL_MODULE.pool_difficulty);
 
-    cJSON_AddNumberToObject(root, "isUsingFallbackStratum", POOL_MODULE.is_using_fallback);
+    cJSON_AddNumberToObject(root, "isUsingFallbackStratum", POOL_MODULE.active_pool_idx != POOL_MODULE.default_pool_idx);
 
     cJSON_AddNumberToObject(root, "isPSRAMAvailable", STATE_MODULE.psram_is_available);
 

--- a/main/pool_module.h
+++ b/main/pool_module.h
@@ -2,6 +2,7 @@
 #define POOL_MODULE_H_
 
 #include <stdint.h>
+#define STRATUM_POOL_CAPACITY 2
 typedef struct
 {
     // The URL of the mining pool.
@@ -21,7 +22,7 @@ typedef struct
 typedef struct
 {
     // The configured pools to connect to.
-    stratum_pool pools[2];
+    stratum_pool pools[STRATUM_POOL_CAPACITY];
     
     // The currently active pool.
     uint8_t active_pool_idx;

--- a/main/pool_module.h
+++ b/main/pool_module.h
@@ -1,49 +1,39 @@
 #ifndef POOL_MODULE_H_
 #define POOL_MODULE_H_
 
+#include <stdint.h>
 typedef struct
 {
-    // The URL of the main mining pool.
-    char * pool_url;
+    // The URL of the mining pool.
+    char * url;
+    // The port number on which the mining pool operates.
+    uint16_t port;
+    // The username for authenticating with the mining pool.
+    char * user;
+    // The password for authenticating with the mining pool.
+    char * pass;
+    // The suggested difficulty level set on the mining pool.
+    uint16_t difficulty;
+     // A flag indicating whether the mining pool supports extranonce subscription.
+    bool extranonce_subscribe;
+} stratum_pool;
 
-    // The URL of the fallback mining pool in case the main one fails.
-    char * fallback_pool_url;
+typedef struct
+{
+    // The configured pools to connect to.
+    stratum_pool pools[2];
+    
+    // The currently active pool.
+    uint8_t active_pool_idx;
 
-    // The port number on which the main mining pool operates.
-    uint16_t pool_port;
-
-    // The port number on which the fallback mining pool operates.
-    uint16_t fallback_pool_port;
-
-    // The username for authenticating with the main mining pool.
-    char * pool_user;
-
-    // The username for authenticating with the fallback mining pool.
-    char * fallback_pool_user;
-
-    // The password for authenticating with the main mining pool.
-    char * pool_pass;
-
-    // The password for authenticating with the fallback mining pool.
-    char * fallback_pool_pass;
-
-    // The difficulty level set on the main mining pool.
+    // The difficulty level set on the active mining pool.
     uint16_t pool_difficulty;
-
-    // The difficulty level set on the fallback mining pool.
-    uint16_t fallback_pool_difficulty;
-
-    // A flag indicating whether the main mining pool supports extranonce subscription.
-    bool pool_extranonce_subscribe;
-
-    // A flag indicating whether the fallback mining pool supports extranonce subscription.
-    bool fallback_pool_extranonce_subscribe;
 
     // The average response time of the main mining pool to requests.
     double response_time;
 
     // A flag indicating if the system is currently using the fallback pool instead of the main one.
-    bool is_using_fallback;
+    uint8_t default_pool_idx;
 }PoolModule;
 
 extern PoolModule POOL_MODULE;

--- a/main/screen.c
+++ b/main/screen.c
@@ -431,7 +431,7 @@ static void screen_update_cb(lv_timer_t * timer)
 
     current_screen_time_ms += SCREEN_UPDATE_MS;
 
-    char * pool_url = POOL_MODULE.is_using_fallback ? POOL_MODULE.fallback_pool_url : POOL_MODULE.pool_url;
+    char * pool_url = POOL_MODULE.pools[POOL_MODULE.active_pool_idx].url;
     if (strcmp(lv_label_get_text(urls_mining_url_label), pool_url) != 0) {
         lv_label_set_text(urls_mining_url_label, pool_url);
     }

--- a/main/system.c
+++ b/main/system.c
@@ -86,31 +86,34 @@ void SYSTEM_init_system()
     STATE_MODULE.FOUND_BLOCK = false;
     
     // set the pool url
-    POOL_MODULE.pool_url = nvs_config_get_string(NVS_CONFIG_STRATUM_URL, CONFIG_STRATUM_URL);
-    POOL_MODULE.fallback_pool_url = nvs_config_get_string(NVS_CONFIG_FALLBACK_STRATUM_URL, CONFIG_FALLBACK_STRATUM_URL);
+    POOL_MODULE.pools[0].url = nvs_config_get_string(NVS_CONFIG_STRATUM_URL, CONFIG_STRATUM_URL);
+    POOL_MODULE.pools[1].url = nvs_config_get_string(NVS_CONFIG_FALLBACK_STRATUM_URL, CONFIG_FALLBACK_STRATUM_URL);
 
     // set the pool port
-    POOL_MODULE.pool_port = nvs_config_get_u16(NVS_CONFIG_STRATUM_PORT, CONFIG_STRATUM_PORT);
-    POOL_MODULE.fallback_pool_port = nvs_config_get_u16(NVS_CONFIG_FALLBACK_STRATUM_PORT, CONFIG_FALLBACK_STRATUM_PORT);
+    POOL_MODULE.pools[0].port = nvs_config_get_u16(NVS_CONFIG_STRATUM_PORT, CONFIG_STRATUM_PORT);
+    POOL_MODULE.pools[1].port = nvs_config_get_u16(NVS_CONFIG_FALLBACK_STRATUM_PORT, CONFIG_FALLBACK_STRATUM_PORT);
 
     // set the pool user
-    POOL_MODULE.pool_user = nvs_config_get_string(NVS_CONFIG_STRATUM_USER, CONFIG_STRATUM_USER);
-    POOL_MODULE.fallback_pool_user = nvs_config_get_string(NVS_CONFIG_FALLBACK_STRATUM_USER, CONFIG_FALLBACK_STRATUM_USER);
+    POOL_MODULE.pools[0].user = nvs_config_get_string(NVS_CONFIG_STRATUM_USER, CONFIG_STRATUM_USER);
+    POOL_MODULE.pools[1].user = nvs_config_get_string(NVS_CONFIG_FALLBACK_STRATUM_USER, CONFIG_FALLBACK_STRATUM_USER);
 
     // set the pool password
-    POOL_MODULE.pool_pass = nvs_config_get_string(NVS_CONFIG_STRATUM_PASS, CONFIG_STRATUM_PW);
-    POOL_MODULE.fallback_pool_pass = nvs_config_get_string(NVS_CONFIG_FALLBACK_STRATUM_PASS, CONFIG_FALLBACK_STRATUM_PW);
+    POOL_MODULE.pools[0].pass = nvs_config_get_string(NVS_CONFIG_STRATUM_PASS, CONFIG_STRATUM_PW);
+    POOL_MODULE.pools[1].pass = nvs_config_get_string(NVS_CONFIG_FALLBACK_STRATUM_PASS, CONFIG_FALLBACK_STRATUM_PW);
 
     // set the pool difficulty
-    POOL_MODULE.pool_difficulty = nvs_config_get_u16(NVS_CONFIG_STRATUM_DIFFICULTY, CONFIG_STRATUM_DIFFICULTY);
-    POOL_MODULE.fallback_pool_difficulty = nvs_config_get_u16(NVS_CONFIG_FALLBACK_STRATUM_DIFFICULTY, CONFIG_FALLBACK_STRATUM_DIFFICULTY);
+    POOL_MODULE.pools[0].difficulty = nvs_config_get_u16(NVS_CONFIG_STRATUM_DIFFICULTY, CONFIG_STRATUM_DIFFICULTY);
+    POOL_MODULE.pools[1].difficulty =
+        nvs_config_get_u16(NVS_CONFIG_FALLBACK_STRATUM_DIFFICULTY, CONFIG_FALLBACK_STRATUM_DIFFICULTY);
 
     // set the pool extranonce subscribe
-    POOL_MODULE.pool_extranonce_subscribe = nvs_config_get_u16(NVS_CONFIG_STRATUM_EXTRANONCE_SUBSCRIBE, STRATUM_EXTRANONCE_SUBSCRIBE);
-    POOL_MODULE.fallback_pool_extranonce_subscribe = nvs_config_get_u16(NVS_CONFIG_FALLBACK_STRATUM_EXTRANONCE_SUBSCRIBE, FALLBACK_STRATUM_EXTRANONCE_SUBSCRIBE);
+    POOL_MODULE.pools[0].extranonce_subscribe =
+        nvs_config_get_u16(NVS_CONFIG_STRATUM_EXTRANONCE_SUBSCRIBE, STRATUM_EXTRANONCE_SUBSCRIBE);
+    POOL_MODULE.pools[1].extranonce_subscribe =
+        nvs_config_get_u16(NVS_CONFIG_FALLBACK_STRATUM_EXTRANONCE_SUBSCRIBE, FALLBACK_STRATUM_EXTRANONCE_SUBSCRIBE);
 
     // set fallback to false.
-    POOL_MODULE.is_using_fallback = false;
+    POOL_MODULE.default_pool_idx = 0;
 
     // Initialize overheat_mode
     STATE_MODULE.overheat_mode = nvs_config_get_u16(NVS_CONFIG_OVERHEAT_MODE, 0);

--- a/main/tasks/stratum_task.c
+++ b/main/tasks/stratum_task.c
@@ -178,7 +178,7 @@ void stratum_primary_heartbeat()
 
         int send_uid = 1;
         STRATUM_V1_subscribe(sock, send_uid++, DEVICE_CONFIG.family.asic.name);
-        STRATUM_V1_authorize(sock, send_uid++, POOL_MODULE.pools[POOL_MODULE.active_pool_idx].user, POOL_MODULE.pools[POOL_MODULE.active_pool].pass);
+        STRATUM_V1_authorize(sock, send_uid++, POOL_MODULE.pools[POOL_MODULE.active_pool_idx].user, POOL_MODULE.pools[POOL_MODULE.active_pool_idx].pass);
 
         char recv_buffer[BUFFER_SIZE];
         memset(recv_buffer, 0, BUFFER_SIZE);

--- a/main/tasks/stratum_task.c
+++ b/main/tasks/stratum_task.c
@@ -95,7 +95,7 @@ void stratum_close_connection()
 
 int stratum_submit_share(char * jobid, char * extranonce2, uint32_t ntime, uint32_t nonce, uint32_t version)
 {
-    char * user = POOL_MODULE.is_using_fallback ? POOL_MODULE.fallback_pool_user : POOL_MODULE.pool_user;
+    char * user = POOL_MODULE.pools[POOL_MODULE.active_pool_idx].user;
     int ret = STRATUM_V1_submit_share(
         sock,
         send_uid++,
@@ -129,7 +129,7 @@ void stratum_primary_heartbeat()
 
     while (1)
     {
-        if (POOL_MODULE.is_using_fallback == false) {
+        if (POOL_MODULE.active_pool_idx == POOL_MODULE.default_pool_idx) {
             vTaskDelay(10000 / portTICK_PERIOD_MS);
             continue;
         }
@@ -178,7 +178,7 @@ void stratum_primary_heartbeat()
 
         int send_uid = 1;
         STRATUM_V1_subscribe(sock, send_uid++, DEVICE_CONFIG.family.asic.name);
-        STRATUM_V1_authorize(sock, send_uid++, POOL_MODULE.pool_user, POOL_MODULE.pool_pass);
+        STRATUM_V1_authorize(sock, send_uid++, POOL_MODULE.pools[POOL_MODULE.active_pool_idx].user, POOL_MODULE.pools[POOL_MODULE.active_pool].pass);
 
         char recv_buffer[BUFFER_SIZE];
         memset(recv_buffer, 0, BUFFER_SIZE);
@@ -194,7 +194,6 @@ void stratum_primary_heartbeat()
 
         if (strstr(recv_buffer, "mining.notify") != NULL) {
             ESP_LOGI(TAG, "Heartbeat successful and in fallback mode. Switching back to primary.");
-            POOL_MODULE.is_using_fallback = false;
             stratum_close_connection();
             continue;
         }
@@ -273,12 +272,12 @@ void decode_mining_notification(const mining_notify *mining_notification)
 void stratum_task(void * pvParameters)
 {
 
-    primary_stratum_url = POOL_MODULE.pool_url;
-    primary_stratum_port = POOL_MODULE.pool_port;
-    char * stratum_url = POOL_MODULE.pool_url;
-    uint16_t port = POOL_MODULE.pool_port;
-    bool extranonce_subscribe = POOL_MODULE.pool_extranonce_subscribe;
-    uint16_t difficulty = POOL_MODULE.pool_difficulty;
+    primary_stratum_url = POOL_MODULE.pools[POOL_MODULE.active_pool_idx].url;
+    primary_stratum_port = POOL_MODULE.pools[POOL_MODULE.active_pool_idx].port;
+    char * stratum_url = POOL_MODULE.pools[POOL_MODULE.active_pool_idx].url;
+    uint16_t port = POOL_MODULE.pools[POOL_MODULE.active_pool_idx].port;
+    bool extranonce_subscribe = POOL_MODULE.pools[POOL_MODULE.active_pool_idx].extranonce_subscribe;
+    uint16_t difficulty = POOL_MODULE.pools[POOL_MODULE.active_pool_idx].difficulty;
 
     STRATUM_V1_initialize_buffer();
     char host_ip[20];
@@ -299,14 +298,13 @@ void stratum_task(void * pvParameters)
 
         if (retry_attempts >= MAX_RETRY_ATTEMPTS)
         {
-            if (POOL_MODULE.fallback_pool_url == NULL || POOL_MODULE.fallback_pool_url[0] == '\0') {
+            POOL_MODULE.active_pool_idx = POOL_MODULE.active_pool_idx+1 % 2;
+            if (POOL_MODULE.pools[POOL_MODULE.active_pool_idx].url == NULL || POOL_MODULE.pools[POOL_MODULE.active_pool_idx].url[0] == '\0') {
                 ESP_LOGI(TAG, "Unable to switch to fallback. No url configured. (retries: %d)...", retry_attempts);
-                POOL_MODULE.is_using_fallback = false;
                 retry_attempts = 0;
                 continue;
             }
 
-            POOL_MODULE.is_using_fallback = !POOL_MODULE.is_using_fallback;
             
             // Reset share stats at failover
             for (int i = 0; i < SYSTEM_MODULE.rejected_reason_stats_count; i++) {
@@ -322,10 +320,10 @@ void stratum_task(void * pvParameters)
             retry_attempts = 0;
         }
 
-        stratum_url = POOL_MODULE.is_using_fallback ? POOL_MODULE.fallback_pool_url : POOL_MODULE.pool_url;
-        port = POOL_MODULE.is_using_fallback ? POOL_MODULE.fallback_pool_port : POOL_MODULE.pool_port;
-        extranonce_subscribe = POOL_MODULE.is_using_fallback ? POOL_MODULE.fallback_pool_extranonce_subscribe : POOL_MODULE.pool_extranonce_subscribe;
-        difficulty = POOL_MODULE.is_using_fallback ? POOL_MODULE.fallback_pool_difficulty : POOL_MODULE.pool_difficulty;
+        stratum_url = POOL_MODULE.pools[POOL_MODULE.active_pool_idx].url;
+        port = POOL_MODULE.pools[POOL_MODULE.active_pool_idx].port;
+        extranonce_subscribe = POOL_MODULE.pools[POOL_MODULE.active_pool_idx].extranonce_subscribe;
+        difficulty = POOL_MODULE.pools[POOL_MODULE.active_pool_idx].difficulty;
 
         struct hostent *dns_addr = gethostbyname(stratum_url);
         if (dns_addr == NULL) {
@@ -387,8 +385,8 @@ void stratum_task(void * pvParameters)
         // mining.subscribe - ID: 2
         STRATUM_V1_subscribe(sock, send_uid++, DEVICE_CONFIG.family.asic.name);
 
-        char * username = POOL_MODULE.is_using_fallback ? POOL_MODULE.fallback_pool_user : POOL_MODULE.pool_user;
-        char * password = POOL_MODULE.is_using_fallback ? POOL_MODULE.fallback_pool_pass : POOL_MODULE.pool_pass;
+        char * username = POOL_MODULE.pools[POOL_MODULE.active_pool_idx].user;
+        char * password = POOL_MODULE.pools[POOL_MODULE.active_pool_idx].pass;
 
         int authorize_message_id = send_uid++;
         //mining.authorize - ID: 3

--- a/main/tasks/stratum_task.c
+++ b/main/tasks/stratum_task.c
@@ -298,7 +298,7 @@ void stratum_task(void * pvParameters)
 
         if (retry_attempts >= MAX_RETRY_ATTEMPTS)
         {
-            POOL_MODULE.active_pool_idx = POOL_MODULE.active_pool_idx+1 % 2;
+            POOL_MODULE.active_pool_idx = POOL_MODULE.active_pool_idx+1 % STRATUM_POOL_CAPACITY;
             if (POOL_MODULE.pools[POOL_MODULE.active_pool_idx].url == NULL || POOL_MODULE.pools[POOL_MODULE.active_pool_idx].url[0] == '\0') {
                 ESP_LOGI(TAG, "Unable to switch to fallback. No url configured. (retries: %d)...", retry_attempts);
                 retry_attempts = 0;


### PR DESCRIPTION
as discussed in the osmu discord (https://discord.com/channels/1091348375301013615/1094385611718270977/1416872771924918485), thisll refactor the pool logic to prepare for arbitrary numbers of pool configs

this pr abstracts the pool config to `stratum_pool` structs in a 2-element array. the underlying nvs entries haven't been touched, that'd be a big future refactor thing and is also out of scope for the pr this piggybacks off of x3